### PR TITLE
Log basic usage stats: number of cards opened, load time, time on page (#2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "interactive-expandable-cards",
-  "version": "5.5.1",
+  "version": "5.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/ExpandableCards/index.js
+++ b/src/components/ExpandableCards/index.js
@@ -74,6 +74,9 @@ class ExpandableCards extends Component {
 
   componentWillUnmount() {
     clearInterval(this.measurementInterval);
+    window.removeEventListener('beforeunload', this.sendLog);
+    window.removeEventListener('unload', this.sendLog);
+    this.sendLog();
   }
 
   measureBase() {


### PR DESCRIPTION
Previous pull request + improvements:

1. Use class properties for data that isn't rendered
2. Safer regex handling
3. Let Firestore assign document IDs
4. Remove event listeners at unmount